### PR TITLE
fix-multicore-sync-bug

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -117,6 +117,8 @@ func (b *Bundle) defBundle() di.Def {
 						return err
 					}
 				}
+
+				return nil
 			}
 
 			return handleError(err)


### PR DESCRIPTION
- fix bug in case then we have multierror which contains only os.PathError